### PR TITLE
Return an error when the user cancel the authentication

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -42,7 +42,7 @@ function Twitter(obj, fn) {
   var url = endpoint + '?' + querystring.stringify(obj);
   open(url, function(err, data) {
     if (err) return fn(err);
-    if (data.denied) return fn(new Error('Denied'))
+    if (data.denied) return fn(new Error('Denied'));
     return fn(null, data);
   })
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -42,6 +42,7 @@ function Twitter(obj, fn) {
   var url = endpoint + '?' + querystring.stringify(obj);
   open(url, function(err, data) {
     if (err) return fn(err);
+    if (data.denied) return fn(new Error('Denied'))
     return fn(null, data);
   })
 }


### PR DESCRIPTION
When a user cancel the authentication open-oauth return an object with a key 'denied' so the callback should return an error.
